### PR TITLE
Add flag to toggle between a default day and night temperature

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ The following options, which can be specified before the optional temperature pa
 - `-v`, `--verbose`: display debugging information
 - `-d <delta>`, `--delta <delta>`: shift temperature by the temperature value
 - `-s <screen>`, `--screen <screen>` `N`: use the screen specified by given zero-based index
+- `-t`, `--toggle`: toggle between night and day temperature
 - `-c <crtc>`, `--crtc <crtc>` `N`: use the CRTC specified by given zero-based index
 
 Test xsct using the following command:

--- a/src/xsct.c
+++ b/src/xsct.c
@@ -225,20 +225,25 @@ int main(int argc, char **argv)
     }
     else
     {
-      /* Check if the temp is above 100 less than the norm and change to NIGHT if it is */
-      /* The threashold was chosen to give some room for varients in temp */
-      if (toggle == 1) {
-        screen = 0;
-        temp = get_sct_for_screen(dpy, screen, crtc_specified, fdebug);
-        if (temp.temp > (TEMPERATURE_NORM - 100)) {
-          temp.temp = TEMPERATURE_NIGHT;
-          sct_for_screen(dpy, screen, crtc_specified, temp, fdebug);
+      // Check if the temp is above 100 less than the norm and change to NIGHT if it is
+      // The threashold was chosen to give some room for varients in temp
+        if (toggle != 0)
+        {
+            for (screen = screen_first; screen <= screen_last; screen++)
+            {
+
+            temp = get_sct_for_screen(dpy, screen, crtc_specified, fdebug);
+            if (temp.temp > (TEMPERATURE_NORM - 100))
+            {
+                temp.temp = TEMPERATURE_NIGHT;
+            }
+            else
+            {
+                temp.temp = TEMPERATURE_NORM;
+            }
+                sct_for_screen(dpy, screen, crtc_specified, temp, fdebug);
+            }
         }
-        else {
-          temp.temp = TEMPERATURE_NORM;
-          sct_for_screen(dpy, screen, crtc_specified, temp, fdebug);
-        }
-      }
         if (temp.brightness < 0.0) temp.brightness = 1.0;
         if (screen_specified >= 0)
         {

--- a/src/xsct.c
+++ b/src/xsct.c
@@ -225,22 +225,21 @@ int main(int argc, char **argv)
     }
     else
     {
-      // Check if the temp is above 100 less than the norm and change to NIGHT if it is
-      // The threashold was chosen to give some room for varients in temp
+        // Check if the temp is above 100 less than the norm and change to NIGHT if it is
+        // The threashold was chosen to give some room for varients in temp
         if (toggle != 0)
         {
             for (screen = screen_first; screen <= screen_last; screen++)
             {
-
-            temp = get_sct_for_screen(dpy, screen, crtc_specified, fdebug);
-            if (temp.temp > (TEMPERATURE_NORM - 100))
-            {
-                temp.temp = TEMPERATURE_NIGHT;
-            }
-            else
-            {
-                temp.temp = TEMPERATURE_NORM;
-            }
+                temp = get_sct_for_screen(dpy, screen, crtc_specified, fdebug);
+                if (temp.temp > (TEMPERATURE_NORM - 100))
+                {
+                    temp.temp = TEMPERATURE_NIGHT;
+                }
+                else
+                {
+                    temp.temp = TEMPERATURE_NORM;
+                }
                 sct_for_screen(dpy, screen, crtc_specified, temp, fdebug);
             }
         }

--- a/src/xsct.c
+++ b/src/xsct.c
@@ -17,6 +17,7 @@ static void usage(char * pname)
            "\t-v, --verbose \t xsct will display debugging information\n"
            "\t-d, --delta\t xsct will shift temperature by the temperature value\n"
            "\t-s, --screen N\t xsct will only select screen specified by given zero-based index\n"
+           "\t-t, --toggle \t xsct will toggle between 'day' and 'night' mode\n"
            "\t-c, --crtc N\t xsct will only select CRTC specified by given zero-based index\n", XSCT_VERSION, pname);
 }
 
@@ -161,7 +162,7 @@ int main(int argc, char **argv)
     int i, screen, screens;
     int screen_specified, screen_first, screen_last, crtc_specified;
     struct temp_status temp;
-    int fdebug = 0, fdelta = 0, fhelp = 0;
+    int fdebug = 0, fdelta = 0, fhelp = 0, toggle = 0;
     Display *dpy = XOpenDisplay(NULL);
 
     if (!dpy)
@@ -182,6 +183,7 @@ int main(int argc, char **argv)
         if ((strcmp(argv[i],"-h") == 0) || (strcmp(argv[i],"--help") == 0)) fhelp = 1;
         else if ((strcmp(argv[i],"-v") == 0) || (strcmp(argv[i],"--verbose") == 0)) fdebug = 1;
         else if ((strcmp(argv[i],"-d") == 0) || (strcmp(argv[i],"--delta") == 0)) fdelta = 1;
+        else if ((strcmp(argv[i],"-t") == 0) || (strcmp(argv[i],"--toggle") == 0)) toggle = 1;
         else if ((strcmp(argv[i],"-s") == 0) || (strcmp(argv[i],"--screen") == 0))
         {
             i++;
@@ -223,6 +225,20 @@ int main(int argc, char **argv)
     }
     else
     {
+      /* Check if the temp is above 100 less than the norm and change to NIGHT if it is */
+      /* The threashold was chosen to give some room for varients in temp */
+      if (toggle == 1) {
+        screen = 0;
+        temp = get_sct_for_screen(dpy, screen, crtc_specified, fdebug);
+        if (temp.temp > (TEMPERATURE_NORM - 100)) {
+          temp.temp = TEMPERATURE_NIGHT;
+          sct_for_screen(dpy, screen, crtc_specified, temp, fdebug);
+        }
+        else {
+          temp.temp = TEMPERATURE_NORM;
+          sct_for_screen(dpy, screen, crtc_specified, temp, fdebug);
+        }
+      }
         if (temp.brightness < 0.0) temp.brightness = 1.0;
         if (screen_specified >= 0)
         {

--- a/src/xsct.h
+++ b/src/xsct.h
@@ -20,6 +20,7 @@
 #define XSCT_VERSION "1.9"
 
 #define TEMPERATURE_NORM    6500
+#define TEMPERATURE_NIGHT   4500
 #define TEMPERATURE_ZERO    700
 #define GAMMA_MULT          65535.0
 // Approximation of the `redshift` table from

--- a/xsct.1
+++ b/xsct.1
@@ -26,7 +26,7 @@ Shift temperature by temperature value
 Zero-based index of screen to use.
 .TP
 .B -t, --toggle
-Toggle redshift on and off.
+Toggle between night and day temperature.
 .TP
 .B -c, --crtc N
 Zero-based index of CRTC to use.

--- a/xsct.1
+++ b/xsct.1
@@ -25,6 +25,9 @@ Shift temperature by temperature value
 .B -s, --screen N
 Zero-based index of screen to use.
 .TP
+.B -t, --toggle
+Toggle redshift on and off.
+.TP
 .B -c, --crtc N
 Zero-based index of CRTC to use.
 .TP


### PR DESCRIPTION
Add `--toggle` flag, allowing users to toggle between night (4500 K) and day (6500 K) temperature, depending on current temperature.