### PR TITLE
Address edge case where temp info is reset when brightness goes below 0.0 in delta mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ Test xsct using the following command:
 xsct 3700 0.9 && xsct
 ~~~
 
+# Quirks
+
+- If the delta mode is used to decrease the brightness to below 0.0 and then increased above 0.0, the temperature will reset to 6500K, regardless of whatever it was before the brightness reached 0. This is because the temperature is reset to 0K when the brightness is set equal to or below 0.0 (to verify this, you can run `xsct 0 0.0; xsct`).
+
 # Resources
 
 The following website by Mitchell Charity provides a table for the conversion between black-body temperatures and color pixel values:

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ xsct 3700 0.9 && xsct
 
 # Quirks
 
-- If the delta mode is used to decrease the brightness to below 0.0 and then increased above 0.0, the temperature will reset to 6500K, regardless of whatever it was before the brightness reached 0. This is because the temperature is reset to 0K when the brightness is set equal to or below 0.0 (to verify this, you can run `xsct 0 0.0; xsct`).
+If the delta mode is used to decrease the brightness to below 0.0 and then increased above 0.0, the temperature will reset to 6500 K, regardless of whatever it was before the brightness reached 0.
+This is because the temperature is reset to 0 K when the brightness is set equal to or below 0.0 (to verify this, you can run `xsct 0 0.0; xsct`).
 
 # Resources
 

--- a/src/xsct.c
+++ b/src/xsct.c
@@ -158,11 +158,18 @@ static void sct_for_screen(Display *dpy, int screen, int icrtc, struct temp_stat
 
 static void bound_temp(struct temp_status *const temp)
 {
-    if (temp->temp < TEMPERATURE_ZERO)
+    if (temp->temp <= 0)
+    {
+        // identical behavior when xsct is called in absolute mode with temp == 0
+        fprintf(stderr, "WARNING! Temperatures below %d cannot be displayed.\n", TEMPERATURE_ZERO);
+        temp->temp = TEMPERATURE_NORM;
+    }
+    else if (temp->temp < TEMPERATURE_ZERO)
     {
         fprintf(stderr, "WARNING! Temperatures below %d cannot be displayed.\n", TEMPERATURE_ZERO);
         temp->temp = TEMPERATURE_ZERO;
     }
+
     if (temp->brightness < 0.0)
     {
         fprintf(stderr, "WARNING! Brightness values below 0.0 cannot be displayed.\n");
@@ -297,18 +304,21 @@ int main(int argc, char **argv)
             else
             {
                 // Delta mode: Shift temperature and optionally brightness of each screen by given value
-                if (temp.temp == DELTA_MIN)
+                if (temp.temp == DELTA_MIN || temp.brightness == DELTA_MIN)
                 {
-                    fprintf(stderr, "ERROR! Required temperature value for delta not specified!\n");
+                    fprintf(stderr, "ERROR! Temperature and brightness delta must both be specified!\n");
                 }
                 else
                 {
                     for (screen = screen_first; screen <= screen_last; screen++)
                     {
                         struct temp_status tempd = get_sct_for_screen(dpy, screen, crtc_specified, fdebug);
+
                         tempd.temp += temp.temp;
-                        if (temp.brightness != DELTA_MIN) tempd.brightness += temp.brightness;
+                        tempd.brightness += temp.brightness;
+
                         bound_temp(&tempd);
+
                         sct_for_screen(dpy, screen, crtc_specified, tempd, fdebug);
                     }
                 }

--- a/src/xsct.c
+++ b/src/xsct.c
@@ -161,7 +161,7 @@ static void bound_temp(struct temp_status *const temp)
     if (temp->temp <= 0)
     {
         // identical behavior when xsct is called in absolute mode with temp == 0
-        fprintf(stderr, "WARNING! Temperatures below %d cannot be displayed.\n", TEMPERATURE_ZERO);
+        fprintf(stderr, "WARNING! Temperatures below %d cannot be displayed.\n", 0);
         temp->temp = TEMPERATURE_NORM;
     }
     else if (temp->temp < TEMPERATURE_ZERO)


### PR DESCRIPTION
Before this commit the temperature would be reset to `TEMPERATURE_ZERO` if the brightness was reduced to 0.0 in delta mode. Now it resets to `TEMPERATURE_NORM`. I noticed this because I have a keyboard shortcut which can quickly reduce and increase brightness using the delta mode. 

If you want to test it, you can do: `xsct 6500 -1; xsct -d 0 1`. This results in a red screen, even though it wasn't intended to change the temperature from 6500.

Now the temperature is reset to 6500, which isn't the perfect solution, but at least it's somewhat aligned to passing 0 as a parameter to `xsct` in absolute mode.

Also add small fix to make sure both temp and brightness are provided when in delta mode. 